### PR TITLE
Very minor typo correction

### DIFF
--- a/src/main/docs/common-create-app-groovy.adoc
+++ b/src/main/docs/common-create-app-groovy.adoc
@@ -4,5 +4,5 @@ Create a Groovy Micronaut app using the http://docs.micronaut.io/snapshot/guide/
 
 The previous command creates a micronaut app with the default package `example.micronaut` in a folder named `complete`.
 
-Due to the `--lang groovy` flag, it generates a Groovy Micronaut app that uses the http://gradle.org[Gradle] build system. However, you could use
+Due to the `--lang=groovy` flag, it generates a Groovy Micronaut app that uses the http://gradle.org[Gradle] build system. However, you could use
 other build tools such as `Maven` or other programming languages such as `Java` or `Kotlin`.

--- a/src/main/docs/common-create-app-kotlin.adoc
+++ b/src/main/docs/common-create-app-kotlin.adoc
@@ -4,5 +4,5 @@ Create a Kotlin Micronaut app using the http://docs.micronaut.io/snapshot/guide/
 
 The previous command creates a micronaut app with the default package `example.micronaut` in a folder named `complete`.
 
-Due to the `--lang kotlin` flag, it generates a Kotlin Micronaut app that uses the http://gradle.org[Gradle] build system. However, you could use
+Due to the `--lang=kotlin` flag, it generates a Kotlin Micronaut app that uses the http://gradle.org[Gradle] build system. However, you could use
 other build tools such as `Maven` or other programming languages such as `Java` or `Groovy`.


### PR DESCRIPTION
Added an '=' sign into the two common guides for creating a Kotlin or Groovy application. The example command has the equals, but reference to the `lang` attribute lacks it.