### PR TITLE
use https for grails core repo in guide-build.gradle

### DIFF
--- a/gradle/guide-build.gradle
+++ b/gradle/guide-build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
         mavenLocal()
-        maven { url = "http://repo.grails.org/grails/core" }
+        maven { url = "https://repo.grails.org/grails/core" }
         maven {
             url "https://plugins.gradle.org/m2/"
         }


### PR DESCRIPTION
After an update to Gradle 7.0 non https repositories are unsupported without an explicit opt-in.


Probably better to pr the change upstream?